### PR TITLE
(Under investigation) DLA

### DIFF
--- a/example_imagenet/imagenet_tensorrt_builder/cmdline.ggo
+++ b/example_imagenet/imagenet_tensorrt_builder/cmdline.ggo
@@ -12,5 +12,6 @@ option "in-cache"   - "specify filename to calibration cache when using mode=int
 option "out-cache"  - "specify output filename to calibration cache if using mode=int8 (--calib also needs to be specified)" string typestr="filename" default="" no
 option "max-batch"  b "specify the maximum batch size this model is supposed to receive" int typestr="batch-size" default="1" no
 option "workspace"  w "specify workspace size in GB that TensorRT is allowed to use while building the network" int typestr="GB" default="4" no
+option "dla"        - "specify when you want to use DLA (Need '--mode fp16' together)" flag off
 option "verbose"    v "Verbose mode" no
 

--- a/example_imagenet/imagenet_tensorrt_builder/cmdline.h
+++ b/example_imagenet/imagenet_tensorrt_builder/cmdline.h
@@ -66,6 +66,8 @@ struct gengetopt_args_info
   int workspace_arg;	/**< @brief specify workspace size in GB that TensorRT is allowed to use while building the network (default='4').  */
   char * workspace_orig;	/**< @brief specify workspace size in GB that TensorRT is allowed to use while building the network original value given at command line.  */
   const char *workspace_help; /**< @brief specify workspace size in GB that TensorRT is allowed to use while building the network help description.  */
+  int dla_flag;	/**< @brief specify when you want to use DLA (Need '--mode fp16' together) (default=off).  */
+  const char *dla_help; /**< @brief specify when you want to use DLA (Need '--mode fp16' together) help description.  */
   const char *verbose_help; /**< @brief Verbose mode help description.  */
   
   unsigned int help_given ;	/**< @brief Whether help was given.  */
@@ -79,6 +81,7 @@ struct gengetopt_args_info
   unsigned int out_cache_given ;	/**< @brief Whether out-cache was given.  */
   unsigned int max_batch_given ;	/**< @brief Whether max-batch was given.  */
   unsigned int workspace_given ;	/**< @brief Whether workspace was given.  */
+  unsigned int dla_given ;	/**< @brief Whether dla was given.  */
   unsigned int verbose_given ;	/**< @brief Whether verbose was given.  */
 
 } ;

--- a/example_imagenet/imagenet_tensorrt_builder/imagenet_tensorrt_builder.cpp
+++ b/example_imagenet/imagenet_tensorrt_builder/imagenet_tensorrt_builder.cpp
@@ -86,6 +86,8 @@ int main(int argc, char* argv[]) {
         if(!msg.empty())
             msg += "option(s) need to be specified with \"--mode int8\"";
     }
+    if(args.dla_flag && args.mode_arg != std::string("fp16"))
+        msg += "--dla has to be specified together with --mode fp16";
     if(!msg.empty()) {
         std::cerr << msg << std::endl << std::endl;
         cmdline_parser_print_help();
@@ -113,8 +115,10 @@ int main(int argc, char* argv[]) {
           args.dir_arg, args.in_cache_arg, args.workspace_arg,
           args.max_batch_arg);
     } else if(args.mode_arg == std::string("fp16")) {
-        m = chainer_trt::model::build_fp16(args.dir_arg, args.workspace_arg,
-                                           args.max_batch_arg);
+        auto p = chainer_trt::build_param_fp16(args.dir_arg, args.workspace_arg,
+                                               args.max_batch_arg);
+        p.dla = args.dla_flag;
+        m = chainer_trt::model::build(p);
     } else {
         m = chainer_trt::model::build_fp32(args.dir_arg, args.workspace_arg,
                                            args.max_batch_arg);

--- a/include/chainer_trt/chainer_trt.hpp
+++ b/include/chainer_trt/chainer_trt.hpp
@@ -141,6 +141,8 @@ struct build_param_fp32 : build_param {
  * build_param_fp16 object can be passed to chainer_trt::model::build.
  */
 struct build_param_fp16 : build_param {
+    bool dla = false;
+
     using build_param::build_param; // ctor
 };
 
@@ -292,13 +294,17 @@ public:
      * @param factory Plugin factory. If you implement your own plugin outside
      *   chainer-trt, you have to tell how it's built and called, so you should
      *   register to a plugin factory and pass to this build function.
+     * @param dla Use DLA flag. If the target device has DLA core and you have
+     *   exported your model with DLA option, you can specify true to
+     *   this argument, although it doesn't guarantee DLA to be used.
      * @return Build engine (chainer_trt::model)
      */
     static std::shared_ptr<model>
     build_fp16(const std::string& model_dir, double workspace_gb = 6.0,
                int max_batch_size = 1,
                std::shared_ptr<plugin::plugin_factory> factory =
-                 std::make_shared<plugin::plugin_factory>());
+                 std::make_shared<plugin::plugin_factory>(),
+               bool dla = false);
 
     /**
      * Build an INT8 inference engine. Be noted that performance can be

--- a/python/chainer_trt/__init__.py
+++ b/python/chainer_trt/__init__.py
@@ -9,6 +9,9 @@ from chainer_trt.model_retriever import ModelRetriever     # NOQA
 from chainer_trt.model_retriever import RetainHook         # NOQA
 from chainer_trt.model_retriever import TracebackHook      # NOQA
 
+from chainer_trt.dla_support import DLA                    # NOQA
+from chainer_trt.dla_support import DLABlock               # NOQA
+
 try:
     from chainer_trt import python_interface               # NOQA
     from chainer_trt.python_interface import Buffer        # NOQA

--- a/python/chainer_trt/dla_support.py
+++ b/python/chainer_trt/dla_support.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2019 Preferred Networks, Inc. All rights reserved.
+
+import chainer
+
+
+def DLA(fn):
+    """Tell chainer-trt to enable DLA for a function
+
+    By using DLA, you can tell chainer-trt and TensorRT to try to use DLA
+    for the function call.
+
+    ```
+    h = DLA(F.f1(x))
+    ```
+
+    This doesn't guarantee all the layers to run on DLA.
+    """
+    fn.creator._chainer_trt_enable_dla = True
+    return fn
+
+
+class DLABlock(chainer.FunctionHook):
+    """Tell chainer-trt to enable DLA within a block
+
+    By surrounding a certain series of Chainer Function call with DLABlock,
+    you can tell chainer-trt and TensorRT to try to use DLA for the block.
+
+    ```
+    with DLABlock():
+        h = F.f1(x)
+        h = F.f2(h)
+    ```
+
+    This doesn't guarantee all the layers to run on DLA.
+    """
+    name = 'DLABlock'
+
+    def forward_postprocess(self, function, _):
+        function._chainer_trt_enable_dla = True

--- a/python/chainer_trt/model_retriever.py
+++ b/python/chainer_trt/model_retriever.py
@@ -611,6 +611,10 @@ class ModelRetriever(object):
         dump = self._dump_func_map[type(func)]
         layer_param, weights = dump(self, func, initial_param)
 
+        # Check if DLA is specified
+        if hasattr(func, '_chainer_trt_enable_dla'):
+            layer_param['dla'] = True
+
         # Save weights to binary file if exist
         if weights is not None:
             for name, values in weights.items():

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -628,7 +628,13 @@ namespace internal {
                 auto dla_flag = layer_params.find("dla");
                 if(dla_flag != layer_params.end() &&
                     param_get<bool>(layer_params, "dla")) {
-                    builder->setDeviceType(l, nvinfer1::DeviceType::kDLA);
+                    if(builder->canRunOnDLA(l)) {
+                        builder->setDeviceType(l, nvinfer1::DeviceType::kDLA);
+                    } else {
+                        auto n = param_get<std::string>(layer_params, "name");
+                        std::cerr << "DLA is specified for \"" << n;
+                        std::cerr << "\" but TensorRT does not support.\n";
+                    }
                 }
             }
         }


### PR DESCRIPTION
This implements DLA support.

**Current API design**
* Dump phase (python side)

```
from chainer_trt import DLABlock

with DLABlock():
  h = F.foobar(x)
  h = F.hoge(h)
```

or

```
from chainer_trt import DLA

h = DLA(F.foobar(x))
```

* Build phase, 

```
build_fp16(..., ..., true);     // The last argument

build_param_fp16 p;
p.dla = true;
chainer_trt::model::build(p);
```

In case the function call with either DLA or DLABlock is not actually supported by DLA, it will simply show some warnings and be ignored (not an error).