### PR TITLE
TensorRT 5.1.1.2RC support

### DIFF
--- a/src/include/chainer_trt_impl.hpp
+++ b/src/include/chainer_trt_impl.hpp
@@ -142,7 +142,7 @@ namespace internal {
             (void)cache;
             (void)length;
 
-            throw std::runtime_error("This shouldn't be called");
+            // Do nothing even if it is called
         }
     };
 }


### PR DESCRIPTION
Done:
* TensorRT 5.1.1.2RC seems to call int8_entropy_calibrator_cached::writeCalibrationCache although it is meaningless

TODO:
* Use the new IInt8EntropyCalibrator2
* Replace Slice, LeakyReLU with native ones

Need to rethink:
* Calibration cache file becomes incompatible between 5.0.2.6 and 5.1.1.2. Regression tests will be broken. :thinking: